### PR TITLE
Make Docker install docs clearer & easier to follow

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,13 +1,67 @@
-# DJI-OBS-Stream - Docker
+# DJI-OBS-Stream – Docker
 
-Set up information for NGINX in Docker for RTMP streaming from a DJI drone or other devices that use the RTMP protocol.
+This Docker image packages NGINX for RTMP streaming from a DJI drone (or any RTMP-capable device) so you can easily set up a streaming endpoint without manually configuring NGINX.
 
-It's basically the same as the [Linux version](../Linux/README.md), but in already precooked Docker container.
+You **don’t need to build this image yourself** unless you want to make modifications. Prebuilt images are available on [Docker Hub](https://hub.docker.com/r/prochac/dji-obs-stream/tags) for both:
 
-There are two tags for this image: `latest` and `alpine`.
-The `latest` tag is based on the `ubuntu` image, while the `alpine` tag is based on the `alpine` image.
-Their size at the time of writing is `581MB` and `149MB` respectively.
+- `amd64` (most desktop/server machines)
+- `arm64` (Raspberry Pi, Apple Silicon Macs, etc.)
 
-Both are build for two different architectures: `amd64` and `arm64`.
+---
 
-Available on [Docker Hub](https://hub.docker.com/r/prochac/dji-obs-stream/tags).
+## Image Variants
+
+| Tag      | Base Image | Size (approx.) |
+|----------|------------|----------------|
+| `latest` | `ubuntu`   | 581 MB          |
+| `alpine` | `alpine`   | 149 MB          |
+
+If you’re unsure which to use, start with `alpine` for smaller size, unless you need Ubuntu-specific tooling.
+
+---
+
+## Quick Start
+
+1. **Pull the image** (replace `<tag>` with `latest` or `alpine`):
+
+   ```bash
+   docker pull prochac/dji-obs-stream:<tag>
+   ```
+
+2. **Run the container** (basic example):
+
+   ```bash
+   docker run -d \
+     --name dji-obs-stream \
+     -p 1935:1935 \
+     prochac/dji-obs-stream:<tag>
+   ```
+
+3. **Stream to it from your DJI drone** by setting the RTMP URL in your DJI app to:
+
+   ```url
+   rtmp://<your-server-ip>/live/stream
+   ```
+
+4. **View the stream in OBS**:
+   - Add a **Media Source** or **RTMP Source** in OBS.
+   - Use the same RTMP URL above.
+
+---
+
+## Building Locally (Optional)
+
+If you want to customize the configuration, clone the repo and build your own image:
+
+```bash
+git clone https://github.com/<repo>.git
+cd DJI-OBS-Stream/Docker
+docker build -t my-dji-obs-stream .
+```
+
+---
+
+## Notes
+
+- Make sure port `1935` is open in your firewall if streaming over the internet.
+- `latest` and `alpine` images are **built** for both `amd64` and `arm64` architectures.

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -2,7 +2,7 @@
 
 This Docker image packages NGINX for RTMP streaming from a DJI drone (or any RTMP-capable device) so you can easily set up a streaming endpoint without manually configuring NGINX.
 
-You **don’t need to build this image yourself** unless you want to make modifications. Prebuilt images are available on [Docker Hub](https://hub.docker.com/r/prochac/dji-obs-stream/tags) for both:
+Prebuilt images are available on [Docker Hub](https://hub.docker.com/r/prochac/dji-obs-stream/tags) for both:
 
 - `amd64` (most desktop/server machines)
 - `arm64` (Raspberry Pi, Apple Silicon Macs, etc.)


### PR DESCRIPTION
Hey! 👋
I cleaned up the Docker install docs to make them a bit easier for newcomers (like me) to follow without having to guess what to do next.

What’s new:
* Put the Docker Hub link right at the top so you can’t miss it.
* Added copy-paste-ready docker pull and docker run examples.
* Turned the image variant info into a neat table.
* Gave the setup steps a more “start here → done” flow.

Why:
When I first read the old version, I wasn’t sure whether I should build my own image or grab one from Docker Hub — so I figured if I could make it clearer for myself, it might help others too.